### PR TITLE
feat: support replaceSource (close #10)

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -6,6 +6,7 @@ mod cached_source;
 mod concat_source;
 mod original_source;
 mod raw_source;
+mod replace_source;
 mod source;
 mod source_map_source;
 
@@ -13,6 +14,7 @@ pub use cached_source::CachedSource;
 pub use concat_source::ConcatSource;
 pub use original_source::OriginalSource;
 pub use raw_source::RawSource;
+pub use replace_source::ReplaceSource;
 pub use result::{Error, RspackSourcesError};
 pub use source::{GenMapOption, Source};
 pub use source_map_source::{SourceMapSource, SourceMapSourceOptions, SourceMapSourceSliceOptions};

--- a/core/src/replace_source.rs
+++ b/core/src/replace_source.rs
@@ -1,0 +1,460 @@
+use std::cmp::{max, min};
+use std::rc::Rc;
+use std::slice::SliceIndex;
+
+use smol_str::SmolStr;
+use sourcemap::{SourceMapBuilder, Token};
+
+use crate::source::Source;
+
+pub struct ReplaceSource<T: Source> {
+  inner: T,
+  replacements: Vec<Replacement>,
+}
+
+struct Replacement {
+  start: i32,
+  end: i32,
+  content: SmolStr,
+  name: Option<SmolStr>,
+}
+
+struct SourceCodeIndexer {
+  code: SmolStr,
+  every_line_lens: Vec<u32>,
+  lines_lens_pre_sum: Vec<u32>,
+}
+
+enum PaddedToken<'a> {
+  Token(Token<'a>),
+  Line(u32),
+}
+
+impl PaddedToken<'_> {
+  fn from_token(token: Token) -> PaddedToken {
+    PaddedToken::Token(token)
+  }
+
+  fn from_line(line: u32) -> PaddedToken<'static> {
+    PaddedToken::Line(line)
+  }
+
+  fn get_dst_line(&self) -> u32 {
+    match self {
+      PaddedToken::Token(token) => token.get_dst_line(),
+      PaddedToken::Line(line) => *line,
+    }
+  }
+
+  fn get_src_line(&self) -> Option<u32> {
+    match self {
+      PaddedToken::Token(token) => Some(token.get_src_line()),
+      PaddedToken::Line(_) => None,
+    }
+  }
+
+  fn get_src_col(&self) -> Option<u32> {
+    match self {
+      PaddedToken::Token(token) => Some(token.get_src_col()),
+      PaddedToken::Line(_) => None,
+    }
+  }
+
+  fn get_src_id(&self) -> Option<u32> {
+    match self {
+      PaddedToken::Token(token) => Some(token.get_src_id()),
+      PaddedToken::Line(_) => None,
+    }
+  }
+
+  fn get_name(&self) -> Option<&str> {
+    match self {
+      PaddedToken::Token(token) => token.get_name(),
+      PaddedToken::Line(_) => None,
+    }
+  }
+}
+
+impl SourceCodeIndexer {
+  fn new(code: SmolStr) -> Self {
+    // use a prefix sum array for finding position by (line, col)
+    // line_lens_pre_sum[i] = sum of lines_lens[0..i-1]
+    let every_line_lens: Vec<u32> = code.split('\n').map(|line| line.len() as u32).collect();
+    let lines_lens_pre_sum: Vec<u32> = [0]
+      .iter()
+      .chain(every_line_lens.iter())
+      .scan(0, |sum, i| {
+        *sum += i;
+        Some(*sum)
+      })
+      .collect();
+    Self {
+      code,
+      every_line_lens,
+      lines_lens_pre_sum,
+    }
+  }
+
+  fn get<I>(&self, idx: I) -> Option<&I::Output>
+  where
+    I: SliceIndex<str>,
+  {
+    self.code.get(idx)
+  }
+
+  fn last_position(&self) -> (u32, u32) {
+    (
+      self.every_line_lens.len() as u32,
+      *self.every_line_lens.last().unwrap() as u32,
+    )
+  }
+
+  fn max_position(&self) -> u32 {
+    self.code.len() as u32
+  }
+
+  fn get_position_by_line_col(&self, line: &u32, col: &u32) -> Option<u32> {
+    // sum of char before this line + '\n' * line + col
+    self
+      .lines_lens_pre_sum
+      .get(*line as usize)
+      .map(|chars| chars + line + col)
+  }
+
+  fn get_position_by_token(&self, token: &Token) -> Option<u32> {
+    self.get_position_by_line_col(&token.get_dst_line(), &token.get_dst_col())
+  }
+}
+
+impl<T: Source> ReplaceSource<T> {
+  pub fn new(source: T) -> Self {
+    Self {
+      inner: source,
+      replacements: vec![],
+    }
+  }
+
+  pub fn original(&self) -> &T {
+    &self.inner
+  }
+
+  pub fn insert(&mut self, start: i32, content: &str, name: Option<&str>) {
+    self.replacements.push(Replacement {
+      start,
+      end: start,
+      content: content.into(),
+      name: name.map(|s| s.into()),
+    });
+  }
+
+  pub fn replace(&mut self, start: i32, end: i32, content: &str, name: Option<&str>) {
+    self.replacements.push(Replacement {
+      start,
+      end,
+      content: content.into(),
+      name: name.map(|s| s.into()),
+    });
+  }
+
+  fn sort_replacement(&mut self) {
+    self
+      .replacements
+      .sort_by(|a, b| (a.start, a.end).cmp(&(b.start, b.end)));
+  }
+}
+
+impl<T: Source> Source for ReplaceSource<T> {
+  fn map(&mut self, option: &crate::GenMapOption) -> Option<Rc<sourcemap::SourceMap>> {
+    self.inner.map(option).map(|inner_source_map| {
+      self.sort_replacement();
+
+      // source map may be ";;;AAAA", which means some target code line may not have (src_line, src_col),
+      // but replacement may be delete these lines.
+      // To simplify the code, below code will add PaddedToken for these lines.
+      let mut tokens: Vec<PaddedToken> = vec![];
+      let mut line = 0;
+      inner_source_map.tokens().for_each(|token| {
+        while token.get_dst_line() > line {
+          tokens.push(PaddedToken::from_line(line));
+          line += 1;
+        }
+        tokens.push(PaddedToken::from_token(token));
+        line = token.get_dst_line() + 1;
+      });
+
+      let source_code_indexer = SourceCodeIndexer::new(self.inner.source());
+      let token_positions: Vec<u32> = tokens
+        .iter()
+        .map(|padded_token| match padded_token {
+          PaddedToken::Token(token) => source_code_indexer.get_position_by_token(token).unwrap(),
+          PaddedToken::Line(line) => source_code_indexer
+            .get_position_by_line_col(line, &0)
+            .unwrap(),
+        })
+        .chain([source_code_indexer.max_position()].into_iter())
+        .collect();
+
+      // check if source_content[line][col] is equal to expect
+      // Why this is needed?
+      //
+      // For example, there is an source_map like (It's OriginalSource)
+      //    source_code: "jsx || tsx"
+      //    mappings:    ↑
+      //    target_code: "jsx || tsx"
+      // If replace || to &&, there will be some new mapping information
+      //    source_code: "jsx || tsx"
+      //    mappings:    ↑    ↑  ↑
+      //    target_code: "jsx && tsx"
+      //
+      // In this case, because source_content[line][col] is equal to target, we can split this mapping correctly,
+      // Therefore, we can add some extra mappings for this replace operation.
+      //
+      // But for this example, source_content[line][col] is not equal to target (It's SourceMapSource)
+      //    source_code: "<div />"
+      //    mappings:    ↑
+      //    target_code: "jsx || tsx"
+      // If replace || to && also, then
+      //    source_code: "<div />"
+      //    mappings:    ↑
+      //    target_code: "jsx && tsx"
+      //
+      // In this case, we can't split this mapping.
+      // webpack-sources also have this function, refer https://github.com/webpack/webpack-sources/blob/main/lib/ReplaceSource.js#L158
+      let check_origin_content = |source_content: Option<&str>,
+                                  line: Option<u32>,
+                                  col: Option<u32>,
+                                  expect: Option<&str>| {
+        if line.is_none() || col.is_none() || expect.is_none() {
+          return false;
+        }
+        let content = source_content.and_then(|s| s.split('\n').nth(line.unwrap() as usize));
+        if content.is_none() {
+          return false;
+        }
+        return content
+          .unwrap()
+          .get(col.unwrap() as usize..col.unwrap() as usize + expect.unwrap().len())
+          == expect;
+      };
+
+      let mut sm_builder = SourceMapBuilder::new(inner_source_map.get_file());
+      let mut generated_line = 0;
+      let mut generated_column = 0;
+      let mut last_generated_line = None;
+      let mut last_src_line = None;
+      let mut last_src_column = None;
+      let mut last_src_id = None;
+
+      let mut add_mapping = |content_length: u32,
+                             new_line_num: u32,
+                             src_line: Option<u32>,
+                             src_col: Option<u32>,
+                             src_id: Option<u32>,
+                             name: Option<&str>| {
+        // Only add token when content_length is not empty or it is "\n" (which means content_length is 0 but new_line_num is 1)
+        // This can avoid source_map have duplicate (dst_line, dst_col) token.
+        // Because there may be an operation like inserting an empty string.
+        if new_line_num == 0 && content_length == 0 {
+          return;
+        }
+
+        if option.columns || generated_column == 0 {
+          if src_line.is_some() && src_col.is_some() {
+            // when there are two position corresponding one src position, should not emit twice
+            // for example: 1:0 -> 1:1, 1:5 -> 1:1 x
+            //              1:0 -> 1:1 ✓
+            // but if two position are not in one line is ok
+            // for example:
+            //              1:0 -> 1:1, 2:0 -> 1:1 ✓
+            if src_line != last_src_line
+              || src_col != last_src_column
+              || src_id != last_src_id
+              || Some(generated_line) != last_generated_line
+            {
+              sm_builder.add(
+                generated_line,
+                generated_column,
+                src_line.unwrap(),
+                src_col.unwrap(),
+                src_id.and_then(|idx| inner_source_map.get_source(idx)),
+                name,
+              );
+              last_generated_line = Some(generated_line);
+              last_src_line = src_line;
+              last_src_column = src_col;
+              last_src_id = src_id;
+            }
+          }
+        }
+
+        if new_line_num != 0 {
+          generated_line += new_line_num;
+          generated_column = 0;
+        } else {
+          generated_column += content_length;
+        }
+      };
+
+      let mut replace_idx = 0;
+      let mut token_idx = 0;
+      let mut token_split_offset = 0;
+      let mut src_offset = 0;
+
+      while replace_idx < self.replacements.len() && token_idx < tokens.len() {
+        let replacement = &self.replacements[replace_idx];
+        let token = tokens.get(token_idx).unwrap();
+        let next_token = tokens.get(token_idx + 1);
+
+        // replacement.start or end can be negative, but it just used for sort order.
+        // when used, it can be regarded as 0
+        let replace_start: u32 = replacement.start.try_into().unwrap_or(0);
+        let replace_end: u32 = replacement.end.try_into().unwrap_or(0);
+        let mut token_start = token_positions[token_idx as usize] + token_split_offset;
+        let mut token_end = token_positions[token_idx as usize + 1];
+
+        // source_code: _______________________________________________________
+        //                  ↑         ↑          ↑          ↑           ↑
+        //                  |         |   replace_start     |     replace_end
+        //       token_original_start |                 token_end
+        //                            |
+        //                       token_start
+        //                   __________
+        //                   ↑        ↑
+        //                 token_split_offset
+
+        if replace_start >= token_end {
+          // emit whole token
+          add_mapping(
+            token_end - token_start,
+            next_token.map_or(0, |next| next.get_dst_line() - token.get_dst_line()),
+            token.get_src_line(),
+            token.get_src_col().map(|col| col + src_offset),
+            token.get_src_id(),
+            token.get_name(),
+          );
+          token_idx += 1;
+          token_split_offset = 0;
+          src_offset = 0;
+        } else if replace_start > token_start {
+          // emit some token and split it
+          add_mapping(
+            replace_start - token_start,
+            0,
+            token.get_src_line(),
+            token.get_src_col().map(|col| col + src_offset),
+            token.get_src_id(),
+            token.get_name(),
+          );
+          if check_origin_content(
+            token
+              .get_src_id()
+              .and_then(|idx| inner_source_map.get_source_contents(idx)),
+            token.get_src_line(),
+            token.get_src_col().map(|col| col + token_split_offset),
+            source_code_indexer.get(token_start as usize..replace_start as usize),
+          ) {
+            src_offset += replace_start - token_start;
+          }
+          token_split_offset += replace_start - token_start;
+        } else {
+          // emit replacement
+          let lines: Vec<&str> = replacement.content.split('\n').collect();
+          lines.iter().enumerate().for_each(|(idx, line)| {
+            add_mapping(
+              line.len() as u32,
+              if idx != lines.len() - 1 { 1 } else { 0 },
+              token.get_src_line(),
+              token.get_src_col().map(|col| col + src_offset),
+              token.get_src_id(),
+              replacement.name.as_ref().map(|name| name.as_str()),
+            );
+          });
+          // skip any token that have been wholely replaced
+          while token_end <= replace_end {
+            token_idx += 1;
+            token_split_offset = 0;
+            src_offset = 0;
+            if token_idx >= tokens.len() {
+              break;
+            }
+            token_start = token_positions[token_idx as usize];
+            token_end = token_positions[token_idx as usize + 1];
+          }
+          // skip part of token that have been replaced
+          if token_idx < tokens.len() && replace_end > token_start {
+            let token = tokens.get(token_idx).unwrap();
+            if check_origin_content(
+              token
+                .get_src_id()
+                .and_then(|idx| inner_source_map.get_source_contents(idx)),
+              token.get_src_line(),
+              token.get_src_col().map(|col| col + token_split_offset),
+              source_code_indexer.get(token_start as usize..replace_end as usize),
+            ) {
+              src_offset += replace_end - token_start;
+            }
+            token_split_offset += replace_end - token_start;
+          }
+          replace_idx += 1;
+        }
+      }
+
+      // just emit remaining token!
+      // if token iterate finished, remaining replacement will only produce an insert on the code end, which won't produce source map
+      while token_idx < tokens.len() {
+        let token = tokens.get(token_idx).unwrap();
+        let next_token = tokens.get(token_idx + 1);
+        let token_start = token_positions[token_idx as usize] + token_split_offset;
+        let token_end = token_positions[token_idx as usize + 1];
+
+        add_mapping(
+          token_end - token_start,
+          next_token.map_or(0, |next| next.get_dst_line() - token.get_dst_line()),
+          token.get_src_line(),
+          token.get_src_col().map(|col| col + src_offset),
+          token.get_src_id(),
+          token.get_name(),
+        );
+        token_idx += 1;
+        token_split_offset = 0;
+        src_offset = 0;
+      }
+
+      if option.include_source_contents {
+        inner_source_map
+          .source_contents()
+          .enumerate()
+          .for_each(|(src_id, source_content)| {
+            sm_builder.set_source_contents(src_id as u32, source_content);
+          });
+      }
+
+      Rc::new(sm_builder.into_sourcemap())
+    })
+  }
+
+  fn source(&mut self) -> SmolStr {
+    self.sort_replacement();
+
+    let inner_source_code = self.inner.source();
+
+    // mut_string_push_str is faster that vec join
+    // concatenate strings benchmark, see https://github.com/hoodie/concatenation_benchmarks-rs
+    let mut source_code = String::new();
+    let mut inner_pos = 0;
+    for replacement in &self.replacements {
+      if inner_pos < replacement.start {
+        let end_pos = min(replacement.start as usize, inner_source_code.len());
+        source_code.push_str(&inner_source_code[inner_pos as usize..end_pos as usize]);
+      }
+      source_code.push_str(&replacement.content);
+      inner_pos = min(
+        max(inner_pos, replacement.end),
+        inner_source_code.len() as i32,
+      );
+    }
+    source_code.push_str(&inner_source_code[inner_pos as usize..]);
+
+    source_code.into()
+  }
+}

--- a/core/tests/replace.rs
+++ b/core/tests/replace.rs
@@ -1,0 +1,457 @@
+use std::rc::Rc;
+
+use rspack_sources::{
+  GenMapOption, OriginalSource, ReplaceSource, Source, SourceMapSource, SourceMapSourceOptions,
+};
+use sourcemap::SourceMap;
+
+fn with_readable_mappings(sourcemap: &Rc<SourceMap>) -> String {
+  let mut first = true;
+  let mut last_line = 0;
+  sourcemap
+    .tokens()
+    .map(|token| {
+      format!(
+        "{}:{} ->{} {}:{}{}",
+        if !first && token.get_dst_line() == last_line {
+          ", ".to_owned()
+        } else {
+          first = false;
+          last_line = token.get_dst_line();
+          format!("\n{}", token.get_dst_line() + 1)
+        },
+        token.get_dst_col(),
+        token
+          .get_source()
+          .map_or("".to_owned(), |source| format!(" [{}]", source)),
+        token.get_src_line() + 1,
+        token.get_src_col(),
+        token
+          .get_name()
+          .map_or("".to_owned(), |source| format!(" ({})", source)),
+      )
+    })
+    .collect()
+}
+
+#[test]
+fn should_replace_correctly() {
+  let line1 = "Hello World!";
+  let line2 = "{}";
+  let line3 = "Line 3";
+  let line4 = "Line 4";
+  let line5 = "Line 5";
+  let code = [&line1, &line2, &line3, &line4, &line5, "Last", "Line"].join("\n");
+  let mut source = ReplaceSource::new(OriginalSource::new(code.as_str(), "file.txt"));
+
+  let start_line3 = (line1.len() + line2.len() + 2) as i32;
+  let start_line6 = start_line3 + line3.len() as i32 + line4.len() as i32 + line5.len() as i32 + 3;
+  source.replace(start_line3, start_line6, "", None);
+  source.replace(1, 5, "i ", None);
+  source.replace(1, 5, "bye", None);
+  source.replace(7, 8, "0000", None);
+  source.insert((line1.len() + 2) as i32, "\n Multi Line\n", None);
+  source.replace(start_line6 + 4, start_line6 + 5, " ", None);
+
+  let result = source.source();
+  let result_map = source
+    .map(&GenMapOption {
+      columns: true,
+      ..Default::default()
+    })
+    .expect("replace sources map failed");
+
+  assert_eq!(
+    code,
+    r#"Hello World!
+{}
+Line 3
+Line 4
+Line 5
+Last
+Line"#
+  );
+
+  assert_eq!(
+    result,
+    r#"Hi bye W0000rld!
+{
+ Multi Line
+}
+Last Line"#
+  );
+
+  assert_eq!(
+    with_readable_mappings(&result_map),
+    r#"
+1:0 -> [file.txt] 1:0, :1 -> [file.txt] 1:1, :3 -> [file.txt] 1:5, :8 -> [file.txt] 1:7, :12 -> [file.txt] 1:8
+2:0 -> [file.txt] 2:0, :1 -> [file.txt] 2:1
+3:0 -> [file.txt] 2:1
+4:0 -> [file.txt] 2:1, :1 -> [file.txt] 2:2
+5:0 -> [file.txt] 6:0, :4 -> [file.txt] 6:4, :5 -> [file.txt] 7:0"#
+  );
+
+  let result_list_map = source
+    .map(&GenMapOption {
+      columns: false,
+      ..Default::default()
+    })
+    .expect("replace sources map failed");
+  assert_eq!(
+    with_readable_mappings(&result_list_map),
+    r#"
+1:0 -> [file.txt] 1:0
+2:0 -> [file.txt] 2:0
+3:0 -> [file.txt] 2:1
+4:0 -> [file.txt] 2:1
+5:0 -> [file.txt] 6:0"#
+  );
+}
+
+#[test]
+fn should_replace_multiple_items_correctly() {
+  let line1 = "Hello";
+  let mut source = ReplaceSource::new(OriginalSource::new(
+    ["Hello", "World!"].join("\n").as_str(),
+    "file.txt",
+  ));
+  let original_code = source.source();
+  source.insert(0, "Message: ", None);
+  source.replace(2, (line1.len() + 5) as i32, "y A", None);
+  let result_text = source.source();
+  let result_map = source
+    .map(&GenMapOption {
+      columns: true,
+      ..Default::default()
+    })
+    .expect("failed");
+  let result_list_map = source
+    .map(&GenMapOption {
+      columns: false,
+      ..Default::default()
+    })
+    .expect("failed");
+
+  assert_eq!(
+    original_code,
+    r#"Hello
+World!"#
+  );
+  assert_eq!(result_text, "Message: Hey Ad!");
+  assert_eq!(
+    with_readable_mappings(&result_map),
+    r#"
+1:0 -> [file.txt] 1:0, :11 -> [file.txt] 1:2, :14 -> [file.txt] 2:4"#
+  );
+
+  assert_eq!(
+    with_readable_mappings(&result_list_map),
+    r#"
+1:0 -> [file.txt] 1:0"#
+  );
+}
+
+#[test]
+fn should_prepend_items_correctly() {
+  let mut source = ReplaceSource::new(OriginalSource::new("Line 1", "file.txt"));
+  source.insert(-1, "Line -1\n", None);
+  source.insert(-1, "Line 0\n", None);
+
+  let result_text = source.source();
+  let result_map = source
+    .map(&GenMapOption {
+      columns: true,
+      ..Default::default()
+    })
+    .expect("failed");
+  let result_list_map = source
+    .map(&GenMapOption {
+      columns: false,
+      ..Default::default()
+    })
+    .expect("failed");
+
+  assert_eq!(result_text, "Line -1\nLine 0\nLine 1");
+  assert_eq!(
+    with_readable_mappings(&result_map),
+    r#"
+1:0 -> [file.txt] 1:0
+2:0 -> [file.txt] 1:0
+3:0 -> [file.txt] 1:0"#
+  );
+  assert_eq!(
+    with_readable_mappings(&result_list_map),
+    r#"
+1:0 -> [file.txt] 1:0
+2:0 -> [file.txt] 1:0
+3:0 -> [file.txt] 1:0"#
+  );
+}
+
+#[test]
+fn should_prepend_items_with_replace_at_start_correctly() {
+  let mut source = ReplaceSource::new(OriginalSource::new(
+    ["Line 1", "Line 2"].join("\n").as_str(),
+    "file.txt",
+  ));
+  source.insert(-1, "Line 0\n", None);
+  source.replace(0, 6, "Hello", None);
+  let result_text = source.source();
+  let result_map = source
+    .map(&GenMapOption {
+      columns: true,
+      ..Default::default()
+    })
+    .expect("failed");
+  let result_list_map = source
+    .map(&GenMapOption {
+      columns: false,
+      ..Default::default()
+    })
+    .expect("failed");
+
+  assert_eq!(
+    result_text,
+    r#"Line 0
+Hello
+Line 2"#
+  );
+
+  let mut writer = vec![];
+  result_map.to_writer(&mut writer).expect("failed");
+
+  assert_eq!(
+    String::from_utf8(writer).unwrap(),
+    r#"{"version":3,"sources":["file.txt"],"sourcesContent":["Line 1\nLine 2"],"names":[],"mappings":"AAAA;AAAA,KAAM;AACN"}"#
+  );
+
+  let mut writer = vec![];
+  result_list_map.to_writer(&mut writer).expect("failed");
+
+  assert_eq!(
+    String::from_utf8(writer).unwrap(),
+    r#"{"version":3,"sources":["file.txt"],"sourcesContent":["Line 1\nLine 2"],"names":[],"mappings":"AAAA;AAAA;AACA"}"#
+  );
+}
+
+#[test]
+fn should_append_items_correctly() {
+  let line1 = "Line 1\n";
+  let mut source = ReplaceSource::new(OriginalSource::new(line1, "file.txt"));
+  source.insert((line1.len() + 1) as i32, "Line 2\n", None);
+  let result_text = source.source();
+  let result_map = source
+    .map(&GenMapOption {
+      columns: true,
+      ..Default::default()
+    })
+    .expect("failed");
+  let result_list_map = source
+    .map(&GenMapOption {
+      columns: false,
+      ..Default::default()
+    })
+    .expect("failed");
+
+  assert_eq!(result_text, "Line 1\nLine 2\n");
+
+  let mut writer = vec![];
+  result_map.to_writer(&mut writer).expect("failed");
+  assert_eq!(
+    String::from_utf8(writer).unwrap(),
+    r#"{"version":3,"sources":["file.txt"],"sourcesContent":["Line 1\n"],"names":[],"mappings":"AAAA"}"#
+  );
+
+  let mut writer = vec![];
+  result_list_map.to_writer(&mut writer).expect("failed");
+
+  assert_eq!(
+    String::from_utf8(writer).unwrap(),
+    r#"{"version":3,"sources":["file.txt"],"sourcesContent":["Line 1\n"],"names":[],"mappings":"AAAA"}"#
+  );
+}
+
+#[test]
+fn should_produce_correct_source_map() {
+  let bootstrap_code = "   var hello\n   var world\n";
+  let mut source = ReplaceSource::new(OriginalSource::new(bootstrap_code, "file.js"));
+  source.replace(7, 12, "h", Some("hello"));
+  source.replace(20, 25, "w", Some("world"));
+  let result_map = source
+    .map(&GenMapOption {
+      ..Default::default()
+    })
+    .expect("failed");
+
+  let target_code = source.source();
+  assert_eq!(target_code, "   var h\n   var w\n");
+
+  assert_eq!(
+    with_readable_mappings(&result_map),
+    r#"
+1:0 -> [file.js] 1:0, :7 -> [file.js] 1:7 (hello), :8 -> [file.js] 1:12
+2:0 -> [file.js] 2:0, :7 -> [file.js] 2:7 (world), :8 -> [file.js] 2:12"#
+  );
+
+  let mut writer = vec![];
+  result_map.to_writer(&mut writer).expect("failed");
+  assert_eq!(
+    String::from_utf8(writer).unwrap(),
+    r#"{"version":3,"sources":["file.js"],"sourcesContent":["   var hello\n   var world\n"],"names":["hello","world"],"mappings":"AAAA,OAAOA,CAAK;AACZ,OAAOC,CAAK"}"#
+  );
+}
+
+#[test]
+fn should_allow_replacements_at_the_start() {
+  let map = SourceMap::from_slice(
+    r#"{
+      "version":3,
+      "sources":["abc"],
+      "names":["StaticPage","data","foo"],
+      "mappings":";;AAAA,eAAe,SAASA,UAAT,OAA8B;AAAA,MAARC,IAAQ,QAARA,IAAQ;AAC3C,sBAAO;AAAA,cAAMA,IAAI,CAACC;AAAX,IAAP;AACD",
+      "sourcesContent":["export default function StaticPage({ data }) {\nreturn <div>{data.foo}</div>\n}\n"],
+      "file":"x"
+    }"#.as_bytes(),
+  ).expect("failed");
+
+  let code = r#"import { jsx as _jsx } from "react/jsx-runtime";
+export var __N_SSG = true;
+export default function StaticPage(_ref) {
+  var data = _ref.data;
+  return /*#__PURE__*/_jsx("div", {
+    children: data.foo
+  });
+}"#;
+
+  /*
+    3:0 -> [abc] 1:0, :15 -> [abc] 1:15, :24 -> [abc] 1:24 (StaticPage), :34 -> [abc] 1:15, :41 -> [abc] 1:45
+    4:0 -> [abc] 1:45, :6 -> [abc] 1:37 (data), :10 -> [abc] 1:45, :18 -> [abc] 1:37 (data), :22 -> [abc] 1:45
+    5:0 -> [abc] 2:2, :22 -> [abc] 2:9
+    6:0 -> [abc] 2:9, :14 -> [abc] 2:15 (data), :18 -> [abc] 2:19, :19 -> [abc] 2:20 (foo)
+    7:0 -> [abc] 2:9, :4 -> [abc] 2:2
+    8:0 -> [abc] 3:1
+  */
+
+  let mut source = ReplaceSource::new(SourceMapSource::new(SourceMapSourceOptions {
+    source_code: code.to_string(),
+    name: "source.js".to_string(),
+    source_map: map,
+    original_source: None,
+    inner_source_map: None,
+    remove_original_source: false,
+  }));
+  source.replace(0, 48, "", None);
+  source.replace(49, 56, "", None);
+  source.replace(76, 91, "", None);
+  source.replace(
+    165,
+    169,
+    "(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_0__.jsx)",
+    None,
+  );
+
+  let target_code = source.source();
+  let source_map = source
+    .map(&GenMapOption {
+      ..Default::default()
+    })
+    .expect("failed");
+
+  assert_eq!(
+    target_code,
+    r#"
+var __N_SSG = true;
+function StaticPage(_ref) {
+  var data = _ref.data;
+  return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_0__.jsx)("div", {
+    children: data.foo
+  });
+}"#
+  );
+  assert_eq!(source_map.get_name(0).unwrap(), "StaticPage");
+  assert_eq!(source_map.get_name(1).unwrap(), "data");
+  assert_eq!(source_map.get_name(2).unwrap(), "foo");
+  assert_eq!(
+    source_map.get_source_contents(0).unwrap(),
+    r#"export default function StaticPage({ data }) {
+return <div>{data.foo}</div>
+}
+"#
+  );
+  assert_eq!(source_map.get_file().unwrap(), "x");
+  assert_eq!(source_map.get_source(0).unwrap(), "abc");
+
+  assert_eq!(
+    with_readable_mappings(&source_map),
+    r#"
+3:0 -> [abc] 1:15, :9 -> [abc] 1:24 (StaticPage), :19 -> [abc] 1:15, :26 -> [abc] 1:45
+4:0 -> [abc] 1:45, :6 -> [abc] 1:37 (data), :10 -> [abc] 1:45, :18 -> [abc] 1:37 (data), :22 -> [abc] 1:45
+5:0 -> [abc] 2:2, :22 -> [abc] 2:9
+6:0 -> [abc] 2:9, :14 -> [abc] 2:15 (data), :18 -> [abc] 2:19, :19 -> [abc] 2:20 (foo)
+7:0 -> [abc] 2:9, :4 -> [abc] 2:2
+8:0 -> [abc] 3:1"#
+  );
+}
+
+#[test]
+fn should_not_generate_invalid_mappings_when_replacing_mulitple_lines_of_code() {
+  let mut source = ReplaceSource::new(OriginalSource::new(
+    r#"if (a;b;c) {
+  a; b; c;
+}"#,
+    "document.js",
+  ));
+  source.replace(4, 9, "false", None);
+  source.replace(12, 24, "", None);
+
+  let target_code = source.source();
+  let source_map = source
+    .map(&GenMapOption {
+      ..Default::default()
+    })
+    .expect("failed");
+
+  assert_eq!(target_code, "if (false) {}");
+  assert_eq!(
+    with_readable_mappings(&source_map),
+    r#"
+1:0 -> [document.js] 1:0, :4 -> [document.js] 1:4, :9 -> [document.js] 1:9, :11 -> [document.js] 1:11, :12 -> [document.js] 3:0"#
+  );
+
+  let mut writer = vec![];
+  source_map.to_writer(&mut writer).expect("failed");
+  assert_eq!(
+    String::from_utf8(writer).unwrap(),
+    r#"{"version":3,"sources":["document.js"],"sourcesContent":["if (a;b;c) {\n  a; b; c;\n}"],"names":[],"mappings":"AAAA,IAAI,KAAK,EAAE,CAEX"}"#
+  );
+}
+
+#[test]
+fn test_edge_case() {
+  let line1 = "hello world\n";
+  let mut source = ReplaceSource::new(OriginalSource::new(line1, "file.txt"));
+
+  source.replace(-1, -999, "start2\n", None);
+  source.insert(-2, "start1\n", None);
+  source.replace(999, 10000, "end2", None);
+  source.insert(888, "end1\n", None);
+  source.replace(-1, 999, "replaced!\n", Some("whole"));
+
+  let result_text = source.source();
+  let result_map = source
+    .map(&GenMapOption {
+      columns: true,
+      ..Default::default()
+    })
+    .expect("failed");
+
+  assert_eq!(result_text, "start1\nstart2\nreplaced!\nend1\nend2");
+
+  assert_eq!(
+    with_readable_mappings(&result_map),
+    r#"
+1:0 -> [file.txt] 1:0
+2:0 -> [file.txt] 1:0
+3:0 -> [file.txt] 1:0 (whole)"#
+  );
+}


### PR DESCRIPTION
## Code
- `replace_source.rs`: implement replaceSource
- `replace.rs`: test case

## Test Case
- 1~8 test cases come from [webpack-sources](https://github.com/webpack/webpack-sources/blob/main/test/ReplaceSource.js)
- 9 test case is an edge case test

## ReplaceSource

There are 4 struct: `ReplaceSource`, `Replacement`, `SourceCodeIndexer`, `PaddedToken`.

### Replacement

```rust
struct Replacement {
  start: i32,
  end: i32,
  content: SmolStr,
  name: Option<SmolStr>,
}
```
- it means delete code in `[start, end)`, and insert `content` at start, which correspond `name`
- why use `i32`? when `start` is 0 or negative, it means insert something in the begin of the code, but the lower the `start` is, the earlier the timing of the insertion.

### SourceCodeIndexer

```rust
struct SourceCodeIndexer {
  code: SmolStr,
  every_line_lens: Vec<u32>,
  lines_lens_pre_sum: Vec<u32>,
}

impl SourceCodeIndexer {
  ....
  fn get_position_by_line_col(&self, line: &u32, col: &u32) -> Option<u32> ;
  ....
}
```

It is used for finding the index in the code by giving (line, col). Because all source_map token stores information like `(target_line, target_col)`, but replacement uses index to store `start`, `end`.

For example, source_code is `hello\nworld`, then the 2 line 1 col `o` corresponds `source_code[7]`.

- use a prefix sum array of line lens, in order to optimize performance.

### PaddedToken

```rust
enum PaddedToken<'a> {
  Token(Token<'a>),
  Line(u32),
}
```

source map may be `";;;AAAA"`, which means some target code line may not have `(src_line, src_col)`, but replacement may be delete these lines. To avoid extra if/else, `PaddedToken::Line` will represent for these lines.

## ReplaceSource<T>::map()

Function Step
1. sort replacements by tuple `(start, end)`
2. use `PaddedToken` to preprocessing special situation like `";;;AAAA"`, ensure that every line will have one token at least, 
3. use `SourceCodeIndexer` to calculate every token's `start` and `end`. (the next token's position is the last token's `end`). In the code, `token_position[i]` means the i'th token's start position.
4. because of step 2 and 3, `token_position` must like `[0, .., .. , .., .., last position]`, it's useful for next step's case-by-case handling.
5. create a `sourceMapBuilder` and some variable to maintain now dst_line and dst_col. code doesn't use offset to calculate token's dst position, but calculate it like the way of generating the target code.
6. use two pointer to maintain replacement_idx and token_idx, and then case-by-case handling using `replacement_start`, `replacement_end`, `token_start`, `token_end`.
7. emit remaining token if have.

## Other Special Case

### check_origin_content

```rust
(source_content: Option<&str>,
 line: Option<u32>,
 col: Option<u32>,
 expect: Option<&str>) -> Bool
```

check if `source_content[line][col]` is equal to `expect`. Why this is needed?

For example, there is an source_map like (It's OriginalSource)
```js
source_code: "jsx || tsx"
mappings:    ↑
target_code: "jsx || tsx"
```
If replace `||` to `&&`, there will be some new mapping information
```js
source_code: "jsx || tsx"
mappings:    ↑    ↑  ↑
target_code: "jsx && tsx"
```
In this case, because `source_content[line][col]` is equal to target, we can split this mapping correctly, Therefore, we can add some extra mappings for this replace operation.

But for this example, `source_content[line][col]` is not equal to target (It's SourceMapSource)
```js
source_code: "<div />"
mappings:    ↑
target_code: "jsx || tsx"
```

If replace `||` to `&&` also, then
```js
source_code: "<div />"
mappings:    ↑
target_code: "jsx && tsx"
```
In this case, we can't split this mapping.

webpack-sources also have this function, refer [checkOriginalContent](https://github.com/webpack/webpack-sources/blob/main/lib/ReplaceSource.js#L158)

### No Emit Redundant Mappings

if we insert a string in the code begin, there may be will generated sourceMap like `1:0->1:0; 1:5->1:0`. we should not emit redundant mappings. webpack-sources won't output this redundant information also.

But if it is `1:0 -> 1:5, 2:0 -> 1:5`, it will be output because the line has changed.An example is [tests/ReplaceSource.js](https://github.com/webpack/webpack-sources/blob/main/test/ReplaceSource.js#L255), both mappings on lines 255 and 256 correspond to 2:9, but both are output.