### PR TITLE
fix: strict substring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rspack_sources"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 authors = ["h-a-n-a <andywangsy@gmail.com>", "ahabhgk <ahabhgk@gmail.com>"]
 resolver = "2"
@@ -22,6 +22,7 @@ once_cell = "1"
 parking_lot = "0.12"
 dashmap = "5"
 smol_str = "0.1"
+substring = "1"
 
 [dev-dependencies]
 twox-hash = "1"

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -2,6 +2,7 @@ use std::{borrow::BorrowMut, cell::RefCell};
 
 use hashbrown::HashMap;
 use smol_str::SmolStr;
+use substring::Substring;
 
 use crate::{
   source::{Mapping, OriginalLocation},
@@ -895,9 +896,8 @@ pub fn stream_chunks_of_combined_source_map(
                   .get(inner_original_line as usize - 1)
                   .map_or("", |lines| {
                     let start = inner_original_column as usize;
-                    let end =
-                      (start + location_in_chunk as usize).min(lines.len());
-                    &lines[start..end]
+                    let end = start + location_in_chunk as usize;
+                    lines.substring(start, end)
                   });
                 if &inner_chunk[..location_in_chunk as usize] == original_chunk
                 {
@@ -998,8 +998,8 @@ pub fn stream_chunks_of_combined_source_map(
                   .get(inner_original_line as usize - 1)
                   .map_or("", |i| {
                     let start = inner_original_column as usize;
-                    let end = (start + name.len()).min(i.len());
-                    &i[start..end]
+                    let end = start + name.len();
+                    i.substring(start, end)
                   });
                 if name == original_name {
                   let mut name_index_mapping = name_index_mapping.borrow_mut();


### PR DESCRIPTION
Why use substring crate?

```rust
use substring::Substring;
use unicode_segmentation::UnicodeSegmentation;

let s = "你好";
dbg!(
    s.chars(),         // Chars(['你', '好'])
    s.bytes(),         // Bytes([228, 189, 160, 229, 165, 189])
    &s[1..5],          // panic: byte index 1 is not a char boundary
    s.substring(1, 5), // 好  `substring` is using `chars()` underlying
);

let s = "a̐éö̲\r\n";
dbg!(
    // node -e 'console.log("a̐éö̲\r\n".length)' --> 9
    s.graphemes(true).count(), // 6  Wrong
    s.chars().count(),         // 9  Right
);
```